### PR TITLE
remove redundant template parameter

### DIFF
--- a/BoostGraphTutorial/get_edge_between_vertices.impl
+++ b/BoostGraphTutorial/get_edge_between_vertices.impl
@@ -1,13 +1,10 @@
 #include <boost/graph/adjacency_list.hpp>
 
-template <
-  typename graph,
-  typename vertex_descriptor
->
+template <typename graph>
 typename boost::graph_traits<graph>::edge_descriptor
 get_edge_between_vertices(
-  const vertex_descriptor& vd_from,
-  const vertex_descriptor& vd_to,
+  const typename boost::graph_traits<graph>::vertex_descriptor& vd_from,
+  const typename boost::graph_traits<graph>::vertex_descriptor& vd_to,
   const graph& g
 )
 {


### PR DESCRIPTION
`const typename boost::graph_traits<graph>::vertex_descriptor&`

That's a really long type name for a function parameter :)